### PR TITLE
Add missing __git_prompt_git() function

### DIFF
--- a/git-alias.plugin.zsh
+++ b/git-alias.plugin.zsh
@@ -6,6 +6,17 @@ git_version="${${(As: :)$(git version 2>/dev/null)}[3]}"
 # Functions
 #
 
+# The git prompt's git commands are read-only and should not interfere with
+# other processes. This environment variable is equivalent to running with `git
+# --no-optional-locks`, but falls back gracefully for older versions of git.
+# See git(1) for and git-status(1) for a description of that flag.
+#
+# We wrap in a local function instead of exporting the variable directly in
+# order to avoid interfering with manually-run git commands by the user.
+function __git_prompt_git() {
+  GIT_OPTIONAL_LOCKS=0 command git "$@"
+}
+
 # Outputs the name of the current branch
 # Usage example: git pull origin $(git_current_branch)
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if


### PR DESCRIPTION
Currently commands like `ggfl` are not working because this function is missing.